### PR TITLE
Client initialization using client session cookie

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tririga-js-sdk",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "description": "Lightweight TRIRIGA Javascript Client SDK",
   "author": "Amir Karbasi",

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -47,4 +47,36 @@ export default class Client {
 
     return client;
   }
+
+  /**
+   * Initialize the client using an existing JSESSIONID.
+   *
+   * @remarks
+   * This method validates the session by calling `getCurrentUser()`. If the session is invalid or expired, it will throw an error.
+   * On success, the client is fully initialized with the user context, CSRF token, and web context ID.
+   *
+   * @param sessionId The JSESSIONID value
+   * @param webAppProperties The TRIRIGA environment properties object
+   * @returns An instance of the `Client` object
+   */
+  static async CreateClientWithSessionId(
+    sessionId: string,
+    webAppProperties?: WebAppProperties
+  ): Promise<Client> {
+    const appConfig = await AppConfig.Init(webAppProperties);
+    const client = new Client(appConfig);
+
+    client.auth = new Auth(appConfig, false);
+    client.auth.sessionCookie = `JSESSIONID=${sessionId}`;
+
+    await client.auth.getCurrentUser();
+    await client.auth.updateCsrfToken();
+
+    client.model = new Model(appConfig, client.auth);
+    client.report = new Report(appConfig, client.auth);
+
+    await client.model.Init();
+
+    return client;
+  }
 }


### PR DESCRIPTION
Useful when we run a process on the server-side, while maintaining access to the client session cookie.